### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function attempt(attempts, command, options, end) {
     // display an error message and exit.
     case 'darwin':
     case 'linux':
-      var sudoCmd = ['/usr/bin/sudo -n', env.join(' '), command].join(' ');
+      var sudoCmd = ['/usr/bin/sudo -n', env.join(' '), '-s', command].join(' ');
       break
   }
 


### PR DESCRIPTION
Fix `command not found` error for osx. From testing on El Capitan this doesn't work without the `-s` flag. to actually run the command
