### PR TITLE
enquote call to elevate.exe

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,11 +85,11 @@ function attempt(attempts, command, options, end) {
     case 'win32':
       processOptions.tmpFiles = writeTempBatchFile(command);
       var sudoCmd = [
-          Node.path.join(
+          encloseDoubleQuotes(Node.path.join(
             Node.path.dirname(module.filename),
             Node.process.platform,
             'elevate.exe'
-          ),
+          )),
           '-wait',
           processOptions.tmpFiles.batch
         ].join(' ');


### PR DESCRIPTION
On Windows, if the Electron app/package is located in a folder with a space in its name, the call to elevate.exe fails to execute. This fixes the issue.

(Replaces #7 which I accidentally closed, sorry!)
