### PR TITLE
Support localized sudo messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ function attempt(attempts, command, options, end) {
       break
   }
   var cb = function(error, stdout, stderr) {
-    if (/sudo: a password is required/i.test(stderr)) {
+    if (error && /^sudo:/i.test(stderr)) {
       if (attempts > 0) return end(new Error('User did not grant permission.'));
       if (Node.process.platform === 'linux') {
         // Linux will probably use TTY tickets for sudo timestamps.


### PR DESCRIPTION
I couldn't get this package working because of it was searching for the text `sudo: a password is required`, while the text was `sudo: se requiere una contraseña` due to my Spanish localization, so I've made a little change to allow for other locales.
