### PR TITLE
Use the real returned error msg

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ function linuxExecute(binary, command, options, end) {
   Node.child.exec(string,
     function(error, stdout, stderr) {
       if (error && /Request dismissed|Command failed/i.test(error)) {
-        error = new Error('User did not grant permission.');
+        error = new Error(error.message || error);
       }
       end(error, stdout, stderr);
     }


### PR DESCRIPTION
Fixes #15 by showing the real error message returned by the executed command.
