### PR TITLE
Add missing slash for main entry file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "electron-sudo",
   "version": "4.0.1",
   "description": "Electron subprocess with administrative privileges, prompting the user with an OS dialog if necessary.",
-  "main": ".dist/index.js",
+  "main": "./dist/index.js",
   "author": "Aleksandr Komlev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This PR fixes next error (probably because of invalid path to main entry file).

```
Module not found: Error: Cannot resolve module 'electron-sudo' in ...
```

Temp solution is to use `electron-sudo/dist/index` require path instead.
