### PR TITLE
Fix `u.sent.filter is not a function`

### DIFF
--- a/src/lib/sudoer.js
+++ b/src/lib/sudoer.js
@@ -325,7 +325,7 @@ class SudoerLinux extends SudoerUnix {
         return new Promise(async (resolve, reject) => {
             /* Detect utility for sudo mode */
             if (!self.binary) {
-                self.binary = (await self.getBinary()).filter((v) => v)[0];
+                self.binary = await self.getBinary();
             }
             if (options.env instanceof Object && !options.env.DISPLAY) {
                 // Force DISPLAY variable with default value which is required for UI dialog


### PR DESCRIPTION
When I try to spawn a program with the current code on Ubuntu, it throws up an error saying "`Unhandled rejection TypeError: u.sent.filter is not a function`". Checking the code, I can trace it back to line 328 of `src/lib/sudoer.js`. The problem appears to be that code was left behind after adding it to the `getBinary` function. This PR fixes it by removing the code left behind.